### PR TITLE
correção highlight repetido em today e custom

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -611,7 +611,7 @@
             this.renderCalendar('right');
 
             //highlight any predefined range matching the current start and end dates
-            // this.container.find('.ranges li').removeClass('active');
+            this.container.find('.ranges li').removeClass('active');
             if (this.endDate == null) return;
 
             this.calculateChosenLabel();


### PR DESCRIPTION
Correção para corrigir erro  de highlight duplicado. 

Ao iniciar daterangepicker, ele inicializa normal, mas ao selecionar uma data personalizada e depois abrir novamente o daterangepicker o label `hoje` e `customizado` ficam selecionados e ao selecionar uma data de ontem os labels `hoje`, `ontem` e `customizados` ficam selecionados.

Segue print do erro:

![image](https://user-images.githubusercontent.com/1118305/54530649-176aab00-4962-11e9-8ecc-2b01587d52c1.png)

![image](https://user-images.githubusercontent.com/1118305/54530673-24879a00-4962-11e9-9847-c66b2e813b5b.png)

![image](https://user-images.githubusercontent.com/1118305/54530715-441ec280-4962-11e9-8a9b-8ba9b14bf7e2.png)
 